### PR TITLE
Bump ampli Homebrew formula to 1.36.3

### DIFF
--- a/Formula/ampli.rb
+++ b/Formula/ampli.rb
@@ -1,9 +1,9 @@
 class Ampli < Formula
   desc "The Ampli CLI"
   homepage "https://amplitude.com"
-  url "https://github.com/amplitude/homebrew-ampli/releases/download/v1.36.2/ampli-v1.36.2.tar.gz"
-  version "1.36.2"
-  sha256 "ac7d862189a1bfd4f1563d55e1d4ef352751d8d3eeb4d623ae9f40e4984e72dd"
+  url "https://github.com/amplitude/homebrew-ampli/releases/download/v1.36.3-master-20250220201612.0/ampli-v1.36.3-master-20250220201612.0.tar.gz"
+  version "1.36.3"
+  sha256 "c27227c0044bc39a22c624f3066bfc2c28ff2842326fb0f269d4eca57e7bfe20"
 
   depends_on "node@18"
 


### PR DESCRIPTION
Customers installing the Ampli CLI via Homebrew are stuck on 1.36.2 — `brew upgrade ampli` offers nothing newer even though 1.36.3 is on npm.

**Root cause:** the last release commit (`d589f2c`) added the dev formula (`ampli-dev.rb`) for the `1.36.3-master-…` build but never promoted the stable `ampli.rb`, which stayed pinned at 1.36.2.

**Fix:** point `ampli.rb`'s `url` / `version` / `sha256` at the existing 1.36.3 release asset. Verified against the hosted assets:
- `v1.36.2` tarball → 200, `v1.36.3` (clean stable tag) → **404** (never published), `v1.36.3-master-20250220201612.0` → 200
- the `sha256` (`c27227c0…`) matches the download and the value already declared in `ampli-dev.rb`

Since no clean `v1.36.3` asset exists, the formula references the only hosted 1.36.3 build (the `-master-…` release asset). `brew info ampli` will report `1.36.3`. Longer term the release pipeline should publish a clean `v1.36.3` stable asset and update `ampli.rb` automatically so this promotion isn't manual.